### PR TITLE
Update config.mdx to reflect features only introduced in later versions

### DIFF
--- a/src/content/docs/mc/waystones/config.mdx
+++ b/src/content/docs/mc/waystones/config.mdx
@@ -4,6 +4,7 @@ type: guide
 icon: mdi:cogs
 ---
 import ConfigTable from '../../../../components/ConfigTable.astro'
+import NoteBox from '../../../../components/NoteBox.astro'
 
 <ConfigTable game="mc" mod="waystones" />
 
@@ -11,7 +12,10 @@ import ConfigTable from '../../../../components/ConfigTable.astro'
 
 ## Warp Requirements
 
-Warp Requirements are only available for versions 1.20.6 onwards as of 20th July 2024.
+<NoteBox title="Older Versions of Minecraft">
+Warp Requirements are only available for Minecraft 1.20.6 and above. On older versions, refer to the contents of your config file for alternative solutions.
+</NoteBox>
+
 Warp Requirements are defined in the following format:
 
 ```

--- a/src/content/docs/mc/waystones/config.mdx
+++ b/src/content/docs/mc/waystones/config.mdx
@@ -11,6 +11,7 @@ import ConfigTable from '../../../../components/ConfigTable.astro'
 
 ## Warp Requirements
 
+Warp Requirements are only available for versions 1.20.6 onwards as of 20th July 2024.
 Warp Requirements are defined in the following format:
 
 ```


### PR DESCRIPTION
I had issues getting warprequirements to work with 1.20.1 until the author of this mod very kindly told me that it is only available on 1.20.6 onwards. This reflects that information. Thank you!